### PR TITLE
shut up, pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /lambda
 # Since we don't want to install the whole Pyramid ecosystem just to reuse its canonical
 # serialization, install it with ``--no-deps``.
 ADD requirements.txt constraints.txt /tmp/
-RUN pip install --quiet --target /lambda -r /tmp/requirements.txt -c /tmp/constraints.txt && \
-    pip install --quiet --target /lambda --no-deps kinto-signer -c /tmp/constraints.txt && \
+RUN pip install --disable-pip-version-check --quiet --target /lambda -r /tmp/requirements.txt -c /tmp/constraints.txt && \
+    pip install --disable-pip-version-check --quiet --target /lambda --no-deps kinto-signer -c /tmp/constraints.txt && \
     find /lambda -type d | xargs chmod ugo+rx && \
     find /lambda -type f | xargs chmod ugo+r
 


### PR DESCRIPTION
No more of this noise...


```
...
Step 3/11 : WORKDIR /lambda
 ---> Using cache
 ---> b8316b11edc7
Step 4/11 : ADD requirements.txt constraints.txt /tmp/
 ---> f7724aa357ac
Step 5/11 : RUN pip install --quiet --target /lambda -r /tmp/requirements.txt -c /tmp/constraints.txt &&     pip install --quiet --target /lambda --no-deps kinto-signer -c /tmp/constraints.txt &&     find /lambda -type d | xargs chmod ugo+rx &&     find /lambda -type f | xargs chmod ugo+r
 ---> Running in 107b01f11c54
You are using pip version 19.0.1, however version 19.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
You are using pip version 19.0.1, however version 19.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Removing intermediate container 107b01f11c54
 ---> 186c5825b6c7
Step 6/11 : ADD *.py /lambda/
 ---> b33a8e06cbc1
Step 7/11 : RUN find /lambda -type d | xargs chmod ugo+rx &&     find /lambda -type f | xargs chmod ugo+r
 ---> Running in 9a78fdbf98b0
Removing intermediate container 9a78fdbf98b0
...
```