### PR TITLE
Add sentry on errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   # Note, this means that the python executed to run the pytests is different
   # from the Docker image we build.
   - pip install -r requirements.txt -c constraints.txt
+  - pip install --no-deps kinto-signer -c constraints.txt
   - pip install -r dev.txt
 script:
   - therapist run --use-tracked-files .

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A collection of scripts related to the Remote Settings service.
 
+## Sentry
+
+All commands use Sentry to report any unexpected errors. The `SENTRY_DSN`
+environment variable is not required but is recommended.
+
 ## Commands
 
 Each command can be run, either with Python:
@@ -162,7 +167,6 @@ Environment config:
 Environment config:
 
 - `REDASH_API_KEY`: For Redash (no default, must be set)
-- `SENTRY_DSN`: Private Sentry DSN key (default: *not set*)
 - `REDASH_API_QUERY_URL`: Restful JSON URL for Redash (see code for default)
 - `REDASH_TIMEOUT_SECONDS`: How many seconds to wait for Redash (see code for default)
 - `EXCLUDE_SOURCES`: Comma separated list of sources to ignore (see code for default)
@@ -172,7 +176,7 @@ Environment config:
 Example:
 
 ```
-$ REDASH_API_KEY=xxxxx SENTRY_DSN=yyyyy python3 aws_lambda.py uptake_health
+$ REDASH_API_KEY=xxxxx python3 aws_lambda.py uptake_health
 
 📅 From 2019-03-12 00:00:00 to 2019-03-12 23:59:59
 blocklists/addons                        (good: 1,027,245 bad:    11,081)               1.07%

--- a/tests/test_aws_lambda.py
+++ b/tests/test_aws_lambda.py
@@ -1,0 +1,17 @@
+from aws_lambda import main
+
+
+def test_help(capsys):
+    return_code = main("help")
+    assert not return_code
+    captured = capsys.readouterr()
+    assert "Available commands:" in captured.out
+    assert not captured.err
+
+
+def test_unknown_command(capsys):
+    return_code = main("neverheardof")
+    assert return_code
+    captured = capsys.readouterr()
+    assert "Available commands:" in captured.out
+    assert "neverheardof" in captured.err


### PR DESCRIPTION
Fixes #7 

After this lands, we have a bit of paperwork to do. We need to create 2 Sentry projects. (We already have https://sentry.prod.mozaws.net/operations/rs-uptake-health-dev/ but I don't like that name any more) and we need to ask Ops to set SENTRY_DSN on ALL Lambda configs. 