### PR TITLE
Fix overwriting of records in backport_records lambda

### DIFF
--- a/tests/test_backport_records.py
+++ b/tests/test_backport_records.py
@@ -102,7 +102,7 @@ class TestRecordsFilter(unittest.TestCase):
         responses.add(
             responses.GET,
             self.source_records_uri,
-            json={"data": [{"id": "a", "age": 22, "last_modified": 2},]},
+            json={"data": [{"id": "a", "age": 22, "last_modified": 2}]},
         )
         responses.add(responses.HEAD, self.dest_records_uri, headers={"ETag": '"41"'})
         responses.add(

--- a/tests/test_backport_records.py
+++ b/tests/test_backport_records.py
@@ -102,11 +102,7 @@ class TestRecordsFilter(unittest.TestCase):
         responses.add(
             responses.GET,
             self.source_records_uri,
-            json={
-                "data": [
-                    {"id": "a", "age": 22, "last_modified": 2},
-                ]
-            },
+            json={"data": [{"id": "a", "age": 22, "last_modified": 2},]},
         )
         responses.add(responses.HEAD, self.dest_records_uri, headers={"ETag": '"41"'})
         responses.add(

--- a/tests/test_backport_records.py
+++ b/tests/test_backport_records.py
@@ -87,3 +87,54 @@ class TestRecordsFilter(unittest.TestCase):
                 "path": "/buckets/main-workspace/collections/other/records/b",
             }
         ]
+
+    @responses.activate
+    def test_outdated_records_are_overwritten(self):
+        responses.add(
+            responses.GET,
+            self.server + "/",
+            json={
+                "settings": {"batch_max_requests": 10},
+                "capabilities": {"signer": {"resources": []}},
+            },
+        )
+        responses.add(responses.HEAD, self.source_records_uri, headers={"ETag": '"42"'})
+        responses.add(
+            responses.GET,
+            self.source_records_uri,
+            json={
+                "data": [
+                    {"id": "a", "age": 22, "last_modified": 2},
+                ]
+            },
+        )
+        responses.add(responses.HEAD, self.dest_records_uri, headers={"ETag": '"41"'})
+        responses.add(
+            responses.GET,
+            self.dest_records_uri,
+            json={"data": [{"id": "a", "age": 20, "last_modified": 1}]},
+        )
+        responses.add(responses.POST, self.server + "/batch", json={"responses": []})
+
+        backport_records(
+            event={
+                "server": self.server,
+                "backport_records_source_auth": self.auth,
+                "backport_records_source_bucket": self.source_bid,
+                "backport_records_source_collection": self.source_cid,
+                "backport_records_dest_bucket": self.dest_bid,
+                "backport_records_dest_collection": self.dest_cid,
+            },
+            context=None,
+        )
+
+        assert responses.calls[5].request.method == "POST"
+        posted_records = json.loads(responses.calls[5].request.body)
+        assert posted_records["requests"] == [
+            {
+                "body": {"data": {"age": 22, "id": "a"}},
+                "headers": {"If-Match": '"1"'},
+                "method": "PUT",
+                "path": "/buckets/main-workspace/collections/other/records/a",
+            }
+        ]


### PR DESCRIPTION
The backport_records code didn't manage updates properly.

Basically, it was sending the source record timestamp in the `If-Match` header ([kinto-http reads the passed record by default](https://github.com/Kinto/kinto-http.py/blob/295d7375796ee80bc624e63586101cea1ced47d3/kinto_http/__init__.py#L189-L195)).
