### PR TITLE
Do not exit early if destination collection has pending changes

### DIFF
--- a/commands/backport_records.py
+++ b/commands/backport_records.py
@@ -81,6 +81,10 @@ def backport_records(event, context, **kwargs):
     is_behind = (len(to_create) + len(to_update) + len(to_delete)) > 0
     has_pending_changes = is_behind
     if not is_behind:
+        # When this lambda is ran with a signed collection as
+        # its destination, the destination collection is in the
+        # workspace bucket, and will have a status field among
+        # its metadata.
         data = dest_client.get_collection()["data"]
         has_pending_changes = data.get("status") != "signed"
 

--- a/tests/test_backport_records.py
+++ b/tests/test_backport_records.py
@@ -254,7 +254,6 @@ class TestRecordsBackport(unittest.TestCase):
         )
 
         assert len(responses.calls) == 6
-        print([(c.request.method, c.request.url) for c in responses.calls])
         assert responses.calls[0].request.method == "GET"
         assert responses.calls[0].request.url.endswith(self.source_records_uri)
         assert responses.calls[1].request.method == "GET"


### PR DESCRIPTION
Without this change, the lambda would exit early if the two collections have their records in sync, even if the backported records were not approved and signed.
This should be enough.