### PR TITLE
Use different Megaphone auth tokens for reading and updating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,15 @@ Environment config:
 
 - ``SERVER``: Remote Settings server URL (default: ``http://localhost:8888/v1``)
 - ``MEGAPHONE_URL``: Megaphone service URL
-- ``MEGAPHONE_AUTH``: Megaphone bearer token
+- ``MEGAPHONE_READER_AUTH``: Bearer token for Megaphone read access
+- ``MEGAPHONE_BROADCASTER_AUTH``: Bearer token for Megaphone broadcaster access
 - ``BROADCASTER_ID``: Push broadcaster ID (default: ``remote-settings``)
 - ``CHANNEL_ID``: Push channel ID (default: ``monitor_changes``)
 
 Example:
 
 ```
-$ SERVER=https://settings.prod.mozaws.net/v1 MEGAPHONE_URL="https://push.services.mozilla.com/v1" MEGAPHONE_AUTH="a-b-c" python aws_lambda.py sync_megaphone
+$ SERVER=https://settings.prod.mozaws.net/v1 MEGAPHONE_URL="https://push.services.mozilla.com/v1" MEGAPHONE_READER_AUTH="a-b-c" MEGAPHONE_BROADCASTER_AUTH="d-e-f" python aws_lambda.py sync_megaphone
 ```
 
 

--- a/tests/test_sync_megaphone.py
+++ b/tests/test_sync_megaphone.py
@@ -9,7 +9,8 @@ from commands.sync_megaphone import sync_megaphone
 class TestSyncMegaphone(unittest.TestCase):
     server = "https://fake-server.net/v1"
     megaphone_url = "https://megaphone.tld/v1"
-    megaphone_auth = "bearer-token"
+    megaphone_reader_auth = "reader-token"
+    megaphone_broadcaster_auth = "broadcaster-token"
     broadcast_id = "remote-settings/monitor_changes"
 
     def setUp(self):
@@ -20,6 +21,15 @@ class TestSyncMegaphone(unittest.TestCase):
         self.megaphone_broadcast_uri = (
             f"{self.megaphone_url}/broadcasts/{self.broadcast_id}"
         )
+        self.event = {
+            k: getattr(self, k)
+            for k in [
+                "server",
+                "megaphone_url",
+                "megaphone_reader_auth",
+                "megaphone_broadcaster_auth",
+            ]
+        }
 
     @responses.activate
     def test_does_nothing_if_up_to_date(self):
@@ -56,11 +66,7 @@ class TestSyncMegaphone(unittest.TestCase):
         )
 
         sync_megaphone(
-            event={
-                "server": self.server,
-                "megaphone_url": self.megaphone_url,
-                "megaphone_auth": self.megaphone_auth,
-            },
+            event=self.event,
             context=None,
         )
 
@@ -97,11 +103,7 @@ class TestSyncMegaphone(unittest.TestCase):
         )
 
         sync_megaphone(
-            event={
-                "server": self.server,
-                "megaphone_url": self.megaphone_url,
-                "megaphone_auth": self.megaphone_auth,
-            },
+            event=self.event,
             context=None,
         )
 
@@ -143,11 +145,7 @@ class TestSyncMegaphone(unittest.TestCase):
         )
 
         sync_megaphone(
-            event={
-                "server": self.server,
-                "megaphone_url": self.megaphone_url,
-                "megaphone_auth": self.megaphone_auth,
-            },
+            event=self.event,
             context=None,
         )
 
@@ -156,5 +154,9 @@ class TestSyncMegaphone(unittest.TestCase):
         assert responses.calls[1].request.method == "GET"
         assert responses.calls[2].request.body == '"10"'
         assert (
-            responses.calls[2].request.headers["authorization"] == "Bearer bearer-token"
+            responses.calls[1].request.headers["authorization"] == "Bearer reader-token"
+        )
+        assert (
+            responses.calls[2].request.headers["authorization"]
+            == "Bearer broadcaster-token"
         )


### PR DESCRIPTION
Megaphone auth tokens only give access to either read or write. It's impossible to do both with the same auth token. While we could probably change this on the Megaphone side if we wanted to, I decided it's easiest to change it in the lambda.