### PR TITLE
Do not refresh signatures too often

### DIFF
--- a/commands/refresh_signature.py
+++ b/commands/refresh_signature.py
@@ -45,8 +45,8 @@ def refresh_signature(event, context, **kwargs):
     auth = event.get("refresh_signature_auth") or os.getenv("REFRESH_SIGNATURE_AUTH")
     if auth:
         auth = tuple(auth.split(":", 1)) if ":" in auth else BearerTokenAuth(auth)
-    min_signature_age = event.get("min_signature_age") or os.getenv(
-        "MIN_SIGNATURE_AGE", 5
+    max_signature_age = event.get("max_signature_age") or os.getenv(
+        "MAX_SIGNATURE_AGE", 7
     )
 
     # Look at the collections in the changes endpoint.
@@ -88,7 +88,7 @@ def refresh_signature(event, context, **kwargs):
             if last_signature_date:
                 last_signature_dt = datetime.fromisoformat(last_signature_date)
                 last_signature_age = (utcnow() - last_signature_dt).days
-                if last_signature_age < min_signature_age:
+                if last_signature_age < max_signature_age:
                     print("SKIP (only %s days old)" % last_signature_age)
                     continue
 

--- a/commands/refresh_signature.py
+++ b/commands/refresh_signature.py
@@ -45,7 +45,9 @@ def refresh_signature(event, context, **kwargs):
     auth = event.get("refresh_signature_auth") or os.getenv("REFRESH_SIGNATURE_AUTH")
     if auth:
         auth = tuple(auth.split(":", 1)) if ":" in auth else BearerTokenAuth(auth)
-    min_signature_age = event.get("min_signature_age") or os.getenv("MIN_SIGNATURE_AGE", 5)
+    min_signature_age = event.get("min_signature_age") or os.getenv(
+        "MIN_SIGNATURE_AGE", 5
+    )
 
     # Look at the collections in the changes endpoint.
     bucket = event.get("bucket", "monitor")

--- a/tests/test_refresh_signature.py
+++ b/tests/test_refresh_signature.py
@@ -1,7 +1,7 @@
 import json
 import unittest
-from unittest import mock
 from datetime import datetime, timezone
+from unittest import mock
 
 import responses
 
@@ -30,10 +30,19 @@ class TestSignatureRefresh(unittest.TestCase):
             self.server + "/",
             json={
                 "settings": {"batch_max_requests": 10},
-                "capabilities": {"signer": {"resources": [{
-                    "source": {"bucket": "main-workspace", "collection": None},
-                    "destination": {"bucket": "main", "collection": None},
-                }]}},
+                "capabilities": {
+                    "signer": {
+                        "resources": [
+                            {
+                                "source": {
+                                    "bucket": "main-workspace",
+                                    "collection": None,
+                                },
+                                "destination": {"bucket": "main", "collection": None},
+                            }
+                        ]
+                    }
+                },
             },
         )
 
@@ -48,14 +57,15 @@ class TestSignatureRefresh(unittest.TestCase):
             },
         )
 
-        for cid, date in [("search-config", "2019-01-11T15:11:07.807323+00:00"), ("top-sites", "2019-01-18T15:11:07.807323+00:00")]:
+        for cid, date in [
+            ("search-config", "2019-01-11T15:11:07.807323+00:00"),
+            ("top-sites", "2019-01-18T15:11:07.807323+00:00"),
+        ]:
             responses.add(
                 responses.GET,
                 self.server + "/buckets/main-workspace/collections/" + cid,
                 json={
-                    "data": {
-                        "last_modified": 42, "last_signature_date": date
-                    },
+                    "data": {"last_modified": 42, "last_signature_date": date},
                 },
             )
             responses.add(
@@ -65,7 +75,7 @@ class TestSignatureRefresh(unittest.TestCase):
                     "data": {
                         "last_modified": 43,
                     }
-                }
+                },
             )
 
         patch = mock.patch("commands.refresh_signature.utcnow")

--- a/tests/test_refresh_signature.py
+++ b/tests/test_refresh_signature.py
@@ -1,0 +1,86 @@
+import json
+import unittest
+from unittest import mock
+from datetime import datetime, timezone
+
+import responses
+
+from commands.refresh_signature import refresh_signature
+
+
+class TestSignatureRefresh(unittest.TestCase):
+    server = "https://fake-server.net/v1"
+    auth = ("foo", "bar")
+
+    # def setUp(self):
+    #     self.source_collection_uri = (
+    #         f"{self.server}/buckets/{self.source_bid}/collections/{self.source_cid}"
+    #     )
+    #     self.source_records_uri = f"{self.source_collection_uri}/records"
+
+    #     self.dest_collection_uri = (
+    #         f"{self.server}/buckets/{self.dest_bid}/collections/{self.dest_cid}"
+    #     )
+    #     self.dest_records_uri = f"{self.dest_collection_uri}/records"
+
+    @responses.activate
+    def test_skip_recently_signed(self):
+        responses.add(
+            responses.GET,
+            self.server + "/",
+            json={
+                "settings": {"batch_max_requests": 10},
+                "capabilities": {"signer": {"resources": [{
+                    "source": {"bucket": "main-workspace", "collection": None},
+                    "destination": {"bucket": "main", "collection": None},
+                }]}},
+            },
+        )
+
+        responses.add(
+            responses.GET,
+            self.server + "/buckets/monitor/collections/changes/records",
+            json={
+                "data": [
+                    {"id": "a", "bucket": "main", "collection": "search-config"},
+                    {"id": "b", "bucket": "main", "collection": "top-sites"},
+                ]
+            },
+        )
+
+        for cid, date in [("search-config", "2019-01-11T15:11:07.807323+00:00"), ("top-sites", "2019-01-18T15:11:07.807323+00:00")]:
+            responses.add(
+                responses.GET,
+                self.server + "/buckets/main-workspace/collections/" + cid,
+                json={
+                    "data": {
+                        "last_modified": 42, "last_signature_date": date
+                    },
+                },
+            )
+            responses.add(
+                responses.PATCH,
+                self.server + "/buckets/main-workspace/collections/" + cid,
+                json={
+                    "data": {
+                        "last_modified": 43,
+                    }
+                }
+            )
+
+        patch = mock.patch("commands.refresh_signature.utcnow")
+        self.addCleanup(patch.stop)
+        mocked = patch.start()
+
+        mocked.return_value = datetime(2019, 1, 20).replace(tzinfo=timezone.utc)
+
+        refresh_signature(
+            event={
+                "server": self.server,
+            },
+            context=None,
+        )
+
+        patch_requests = [r for r in responses.calls if r.request.method == "PATCH"]
+
+        assert len(patch_requests) == 1

--- a/tests/test_refresh_signature.py
+++ b/tests/test_refresh_signature.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 from datetime import datetime, timezone
 from unittest import mock


### PR DESCRIPTION
The refresh signature lambda is not smart enough.

It refreshes signatures, even if changes were just published, which is useless.  This creates a lot of entries in collections history, and is not very efficient.

I arbitrarily picked 5 days as the default minimum age, but Normandy server has 7 days by default: https://github.com/mozilla/normandy/blob/c7a3d01f3b8b018a0f0e9abe448342b02f5787ec/normandy/settings.py#L366
I'm happy to change.

![Screenshot from 2021-02-12 17-46-05](https://user-images.githubusercontent.com/546692/107796500-36defe00-6d5a-11eb-84f7-c81926a4da18.png)
