### PR TITLE
Fix backport records behaviour with `group_check_enabled` setting

### DIFF
--- a/commands/backport_records.py
+++ b/commands/backport_records.py
@@ -134,8 +134,6 @@ def backport_records(event, context, **kwargs):
 
     has_autoapproval = not signed_dest[0].get(
         "to_review_enabled", signer_config["to_review_enabled"]
-    ) and not signed_dest[0].get(
-        "group_check_enabled", signer_config["group_check_enabled"]
     )
     if has_autoapproval:
         # Approve the changes.

--- a/tests/test_backport_records.py
+++ b/tests/test_backport_records.py
@@ -193,7 +193,7 @@ class TestRecordsBackport(unittest.TestCase):
                 "capabilities": {
                     "signer": {
                         "to_review_enabled": False,
-                        "group_check_enabled": False,
+                        "group_check_enabled": True,
                         "resources": [
                             {
                                 "source": {


### PR DESCRIPTION
When removing the ability to configure `group_check_enabled`, we switch the exposed value in capability to `true`. The lambda uses this value to determine whether the server has review enabled, which is wrong. This PR fixes this.