### PR TITLE
Add option to set a Sentry environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ A collection of scripts related to the Remote Settings service.
 
 ## Sentry
 
-All commands use Sentry to report any unexpected errors. The `SENTRY_DSN`
-environment variable is not required but is recommended.
+All commands use Sentry to report any unexpected errors. Sentry can be configured with these environment variables, which are recommended, but not required:
+
+- `SENTRY_DSN`: The DSN from the "Client Keys" section in the project settings in Sentry.
+- `SENTRY_ENV`: The environment to use for Sentry, e.g. dev, stage or prod.
 
 ## Commands
 

--- a/aws_lambda.py
+++ b/aws_lambda.py
@@ -9,12 +9,16 @@ from decouple import config
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 SENTRY_DSN = config("SENTRY_DSN", default=None)
+SENTRY_ENV = config("SENTRY_ENV", deafult=None)
 
 if SENTRY_DSN:
     # Note! If you don't do `sentry_sdk.init(DSN)` it will still work
     # to do things like calling `sentry_sdk.capture_exception(exception)`
     # It just means it's a noop.
-    sentry_sdk.init(SENTRY_DSN, integrations=[AwsLambdaIntegration()])
+    env_option = {}
+    if SENTRY_ENV:
+        env_option = {"environment": SENTRY_ENV}
+    sentry_sdk.init(SENTRY_DSN, integrations=[AwsLambdaIntegration()], **env_option)
 
 
 def help_(**kwargs):


### PR DESCRIPTION
I hoped there would be different DSNs for each environment, but it turned out that the environment is a separate setting, so I needed to introduce a new environment variable.

As an alternative to using an evnironment variable, I considered including the env in the event. However, this would mean that we initialize Sentry to a later point, potentially catching fewer exceptions. It would also mean that we add more AWS-specific code shortly before the GCP migration.