### PR TITLE
Build a small bundle for collections that have the startup flag

### DIFF
--- a/commands/build_bundles.py
+++ b/commands/build_bundles.py
@@ -159,6 +159,18 @@ def build_bundles(event, context):
     )
     bundles_to_upload.append("changesets.zip")
 
+    # Build a bundle for collections that are marked with "startup" flag.
+    write_zip(
+        "startup.zip",
+        [
+            ("{bucket}--{metadata[id]}.json".format(**changeset), json.dumps(changeset))
+            for changeset in all_changesets
+            if "startup" in changeset["metadata"].get("flags", [])
+        ],
+    )
+    bundles_to_upload.append("startup.zip")
+
+    # Build attachments bundle for collections which have the option set.
     for changeset in all_changesets:
         bid = changeset["bucket"]
         cid = changeset["metadata"]["id"]


### PR DESCRIPTION
Context:  https://bugzilla.mozilla.org/show_bug.cgi?id=1907327#c2

Bundling all collections is 6MB, which can take several seconds to fetch.

Bundling only collections that are synced right on startup will be around 70KB.

Note: The lambdas still builds a `changesets.zip` archive, that we could leverage in a follow-up work to reduce the number of requests in the background sync. But technically, we could decide to remove it.

